### PR TITLE
fix(resource form): align heading and submit button with page intent

### DIFF
--- a/resources/templates/resources/resource_create.html
+++ b/resources/templates/resources/resource_create.html
@@ -5,7 +5,7 @@
   <div class="container my-4">
     <div class="row">
       <div class="col-12">
-        <h1>Add Study Resource</h1>
+        <h1>{{ heading }} Resource</h1>
         <p class="text-muted">Use this form to share a study resource with the StudyStack community.</p>
       </div>
     </div>
@@ -14,7 +14,7 @@
       <form action="" method="post" enctype="multipart/form-data">
         {% csrf_token %}
         {{ form|crispy }}
-        <button type="submit" class="btn btn-primary btn--resource">Submit</button>
+        <button type="submit" class="btn btn-primary btn--resource">{{ heading }}</button>
       </form>
     </div>
   </div>

--- a/resources/views.py
+++ b/resources/views.py
@@ -398,6 +398,12 @@ class CreateResource(
         form.instance.author = self.request.user
         return super().form_valid(form)
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["heading"] = "Create"
+
+        return context
+
     def get_success_url(self):
         """
         Redirect to the newly created Resource detail view.
@@ -552,6 +558,11 @@ class ResourceUpdate(
         if not resource.pk:
             resource.author = self.request.user
         return super().form_valid(form)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["heading"] = "Edit"
+        return context
 
     def get_success_url(self):
         """


### PR DESCRIPTION
## Summary
Fixes a UX issue where the resource edit page displayed an incorrect "Add Resource" heading.
The form heading and submit button now correctly reflect whether the page is in create or edit mode.

## Changes
- Added an explicit `heading` context variable in create and update views
- Updated the resource form template to use this context consistently

## Issue
Fixes #17