### PR TITLE
Fix/17-edit-resource-heading

### DIFF
--- a/resources/templates/resources/resource_create.html
+++ b/resources/templates/resources/resource_create.html
@@ -14,7 +14,7 @@
       <form action="" method="post" enctype="multipart/form-data">
         {% csrf_token %}
         {{ form|crispy }}
-        <button type="submit" class="btn btn-primary btn--resource">{{ heading }}</button>
+        <button type="submit" class="btn btn-primary btn--resource">{{ heading }} Resource</button>
       </form>
     </div>
   </div>

--- a/resources/views.py
+++ b/resources/views.py
@@ -399,6 +399,15 @@ class CreateResource(
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
+        """
+        Extend the template context with a heading for the update view.
+        Args:
+            **kwargs: Additional keyword arguments passed to the parent
+                implementation.
+        Returns:
+            dict[str, Any]: The template context including a ``heading`` key
+            set to ``"Edit"``.
+        """
         context = super().get_context_data(**kwargs)
         context["heading"] = "Add"
 
@@ -560,6 +569,15 @@ class ResourceUpdate(
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
+        """
+        Extend the template context with a heading for the update view.
+        Args:
+            **kwargs: Additional keyword arguments passed to the parent
+                implementation.
+        Returns:
+            dict[str, Any]: The template context including a ``heading`` key
+            set to ``"Edit"``.
+        """
         context = super().get_context_data(**kwargs)
         context["heading"] = "Edit"
         return context

--- a/resources/views.py
+++ b/resources/views.py
@@ -400,7 +400,7 @@ class CreateResource(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["heading"] = "Create"
+        context["heading"] = "Add"
 
         return context
 


### PR DESCRIPTION
## Summary
Align page context heading and buttons wording with rest of site.
Update button text to match intent.
Document the new methods.

## Changes
- Updated `heading` context in create frrom 'Create' to 'Add' to reflect the navigation.
- Updated the resource form template button to include 'Resource' after the context.
- Document the methods.

## Issue
Fixes #17